### PR TITLE
add database-cluster class

### DIFF
--- a/AWS/Database.d2
+++ b/AWS/Database.d2
@@ -39,5 +39,15 @@ classes: {
         width: 80
         height: 80
     }
+    AWSDatabase-Cluster: {
+        icon: https://icons.terrastruct.com/aws%2FDatabase%2FDatabase.svg
+        icon.near: top-left
+        label.near: top-center
+        style: {
+            stroke: transparent
+            font-color: black
+            fill: '#DFEFF7'
+        }
+    }
 
 }

--- a/AWS/Database.d2
+++ b/AWS/Database.d2
@@ -49,5 +49,4 @@ classes: {
             fill: '#DFEFF7'
         }
     }
-
 }


### PR DESCRIPTION
This pull request includes an addition to the `AWS/Database.d2` file to enhance the visual representation of AWS database clusters. The most important change is the introduction of a new class for `AWSDatabase-Cluster` with specific styling and icon settings.

Enhancements to visual representation:

* [`AWS/Database.d2`](diffhunk://#diff-47a3d7c84527222dbd627ffb36070c661f3457f32da2e94aff9a85d058ac0c6fR42-R51): Added a new class `AWSDatabase-Cluster` with properties for icon URL, icon positioning, label positioning, and style settings, including stroke, font color, and fill color.