### PR TITLE
Add EventBridge Schedule classes to D2 diagram

### DIFF
--- a/AWS/ApplicationIntegration.d2
+++ b/AWS/ApplicationIntegration.d2
@@ -17,4 +17,22 @@ classes: {
         width: 180
         height: 180
     }
+    AWSApplicationIntegration-EventBridgeSchedule: {
+        icon: https://s3-us-west-1.amazonaws.com/terrastruct.uploaded-images/1167825004/dltletonqnjyuksugujmtiswtmukmr.svg
+        shape: image
+        width: 180
+        height: 180
+    }
+    AWSApplicationIntegration-EventBridgeScheduleGroup: {
+        icon: https://s3-us-west-1.amazonaws.com/terrastruct.uploaded-images/1167825004/dltletonqnjyuksugujmtiswtmukmr.svg
+        icon.near: top-left
+        label.near: outside-top-center
+        style: {
+            stroke: "#E7157B"
+            font-color: "#E7157B"
+            fill: transparent
+            stroke-width: 1
+            stroke-dash: 3
+        }
+    }
 }


### PR DESCRIPTION
Introduced AWSApplicationIntegration-EventBridgeSchedule and AWSApplicationIntegration-EventBridgeScheduleGroup classes with custom icons and styles to enhance the ApplicationIntegration D2 diagram.

<img width="609" alt="image" src="https://github.com/user-attachments/assets/ce763b5d-79ef-4bef-bc39-960c7b098845" />
